### PR TITLE
Implemented auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'ie3-institute/OSMoGrid'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Marius Staudt to list of reviewers [#516](https://github.com/ie3-institute/OSMoGrid/issues/501)
 - Create `CITATION.cff` [#531](https://github.com/ie3-institute/OSMoGrid/issues/531)
 - Implemented GitHub Actions Pipeline [#545](https://github.com/ie3-institute/OSMoGrid/issues/545)
+- Implementing auto-merge for dependabot PRs [#556](https://github.com/ie3-institute/OSMoGrid/issues/566)
 
 ### Changed
 - Rely on Java 17


### PR DESCRIPTION
Closes #566 

This pull request introduces a new GitHub Actions workflow to automatically merge Dependabot pull requests and updates the changelog to reflect this new feature.

### New GitHub Actions Workflow:

* [`.github/workflows/dependabot-auto-merge.yml`](diffhunk://#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1R1-R24): Added a new workflow to automatically merge Dependabot pull requests when they meet specific criteria.

### Changelog Update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR44): Added an entry to document the implementation of the auto-merge feature for Dependabot pull requests.